### PR TITLE
Update pe?? completions to use better cursor jump points

### DIFF
--- a/polymer-element-full-strict.sublime-snippet
+++ b/polymer-element-full-strict.sublime-snippet
@@ -18,21 +18,21 @@ Example:
 @demo demo/index.html
 -->
 
-<dom-module id="$1">
+<dom-module id="$2">
 	<template>
 		<style>
 			:host {
 				display: block;
 			}
 		</style>
-		$4
+		$0
 	</template>
 	<script>
 		(function() {
 			'use strict';
 
 			Polymer({
-				is: '$1'
+				is: '$2'
 			});
 		})();
 	</script>

--- a/polymer-element-stylesheet.sublime-snippet
+++ b/polymer-element-stylesheet.sublime-snippet
@@ -1,5 +1,7 @@
 <snippet>
 	<content><![CDATA[
+<link rel="import" href="$1/polymer/polymer.html">
+
 <!--
 A comment describing this element.
 
@@ -16,14 +18,14 @@ Example:
 @demo demo/index.html
 -->
 
-<dom-module id="$1">
-	<link rel="import" type="css" href="$1.css">
+<dom-module id="$2">
+	<link rel="import" type="css" href="$3.css">
 	<template>
-		$4
+		$0
 	</template>
 	<script>
 		Polymer({
-			is: '$1'
+			is: '$2'
 		});
 	</script>
 </dom-module>

--- a/polymer-element.sublime-snippet
+++ b/polymer-element.sublime-snippet
@@ -1,5 +1,7 @@
 <snippet>
 	<content><![CDATA[
+<link rel="import" href="$1/polymer/polymer.html">
+
 <!--
 A comment describing this element
 
@@ -16,18 +18,18 @@ Example:
 @demo demo/index.html
 -->
 
-<dom-module id="$1">
+<dom-module id="$2">
 	<template>
 		<style>
 			:host {
 				display: block;
 			}
 		</style>
-		$4
+		$0
 	</template>
 	<script>
 		Polymer({
-			is: '$1'
+			is: '$2'
 		});
 	</script>
 </dom-module>


### PR DESCRIPTION
Fixed Polymer Element snippets to use more intuitive cursor positioning.
(Changed $4 to $0 for proper exit point)

Added polymer.html import to `pe` and `pes` to match `pefs` snippet.

Notes: The polymer import could be optional by surrounding it like:
`${1:<link rel="import" href="$2/polymer/polymer.html">}`
and incrementing other jump points, or even change the ${1} to include the spacing below it to make deleting it even faster, but I didn't add this as I don't see it as the main use case for this snippet.