### PR TITLE
Polymer 2.0 elements

### DIFF
--- a/polymer-2-element-stylesheet.sublime-snippet
+++ b/polymer-2-element-stylesheet.sublime-snippet
@@ -1,0 +1,49 @@
+<snippet>
+	<content><![CDATA[
+<link rel="import" href="$1/polymer/polymer.html">
+
+<!--
+A comment describing this element
+
+Example:
+
+    <my-elem></my-elem>
+
+Example:
+
+    <my-elem>
+      <h2>Hello my-elem</h2>
+    </my-elem>
+
+@demo demo/index.html
+-->
+
+<dom-module id="$2">
+  <link rel="import" type="css" href="$3.css">
+  <template>
+    ${0:<h2>Hello [[prop1]]</h2>}
+  </template>
+
+  <script>
+    class ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g} extends Polymer.Element {
+      static get is() { return '$2'; }
+      static get properties() {
+        return {
+          prop1: {
+            type: String,
+            value: '$2'
+          }
+        };
+      }
+    }
+
+    window.customElements.define(${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g}.is, ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g});
+  </script>
+</dom-module>
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>pes2</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.html</scope>
+	<description>polymer 2.0 element, external styles</description>
+</snippet>

--- a/polymer-2-element-stylesheet.sublime-snippet
+++ b/polymer-2-element-stylesheet.sublime-snippet
@@ -7,38 +7,38 @@ A comment describing this element
 
 Example:
 
-    <my-elem></my-elem>
+		<my-elem></my-elem>
 
 Example:
 
-    <my-elem>
-      <h2>Hello my-elem</h2>
-    </my-elem>
+		<my-elem>
+			<h2>Hello my-elem</h2>
+		</my-elem>
 
 @demo demo/index.html
 -->
 
 <dom-module id="$2">
-  <link rel="import" type="css" href="$3.css">
-  <template>
-    ${0:<h2>Hello [[prop1]]</h2>}
-  </template>
+	<link rel="import" type="css" href="$3.css">
+	<template>
+		${0:<h2>Hello [[prop1]]</h2>}
+	</template>
 
-  <script>
-    class ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g} extends Polymer.Element {
-      static get is() { return '$2'; }
-      static get properties() {
-        return {
-          prop1: {
-            type: String,
-            value: '$2'
-          }
-        };
-      }
-    }
+	<script>
+		class ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g} extends Polymer.Element {
+			static get is() { return '$2'; }
+			static get properties() {
+				return {
+					prop1: {
+						type: String,
+						value: '$2'
+					}
+				};
+			}
+		}
 
-    window.customElements.define(${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g}.is, ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g});
-  </script>
+		window.customElements.define(${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g}.is, ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g});
+	</script>
 </dom-module>
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->

--- a/polymer-2-element-stylesheet.sublime-snippet
+++ b/polymer-2-element-stylesheet.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<link rel="import" href="$1/polymer/polymer.html">
+<link rel="import" href="${1:../../bower_components}/polymer/polymer.html">
 
 <!--
 A comment describing this element

--- a/polymer-2-element.sublime-snippet
+++ b/polymer-2-element.sublime-snippet
@@ -1,0 +1,53 @@
+<snippet>
+	<content><![CDATA[
+<link rel="import" href="$1/polymer/polymer.html">
+
+<!--
+A comment describing this element
+
+Example:
+
+    <my-elem></my-elem>
+
+Example:
+
+    <my-elem>
+      <h2>Hello my-elem</h2>
+    </my-elem>
+
+@demo demo/index.html
+-->
+
+<dom-module id="$2">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    ${0:<h2>Hello [[prop1]]</h2>}
+  </template>
+
+  <script>
+    class ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g} extends Polymer.Element {
+      static get is() { return '$2'; }
+      static get properties() {
+        return {
+          prop1: {
+            type: String,
+            value: '$2'
+          }
+        };
+      }
+    }
+
+    window.customElements.define(${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g}.is, ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g});
+  </script>
+</dom-module>
+]]></content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>pe2</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>text.html</scope>
+	<description>polymer 2.0 element</description>
+</snippet>

--- a/polymer-2-element.sublime-snippet
+++ b/polymer-2-element.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<link rel="import" href="$1/polymer/polymer.html">
+<link rel="import" href="${1:../../bower_components}/polymer/polymer.html">
 
 <!--
 A comment describing this element

--- a/polymer-2-element.sublime-snippet
+++ b/polymer-2-element.sublime-snippet
@@ -7,42 +7,42 @@ A comment describing this element
 
 Example:
 
-    <my-elem></my-elem>
+	<my-elem></my-elem>
 
 Example:
 
-    <my-elem>
-      <h2>Hello my-elem</h2>
-    </my-elem>
+	<my-elem>
+		<h2>Hello my-elem</h2>
+	</my-elem>
 
 @demo demo/index.html
 -->
 
 <dom-module id="$2">
-  <template>
-    <style>
-      :host {
-        display: block;
-      }
-    </style>
-    ${0:<h2>Hello [[prop1]]</h2>}
-  </template>
+	<template>
+		<style>
+			:host {
+				display: block;
+			}
+		</style>
+		${0:<h2>Hello [[prop1]]</h2>}
+	</template>
 
-  <script>
-    class ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g} extends Polymer.Element {
-      static get is() { return '$2'; }
-      static get properties() {
-        return {
-          prop1: {
-            type: String,
-            value: '$2'
-          }
-        };
-      }
-    }
+	<script>
+		class ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g} extends Polymer.Element {
+			static get is() { return '$2'; }
+			static get properties() {
+				return {
+					prop1: {
+						type: String,
+						value: '$2'
+					}
+				};
+			}
+		}
 
-    window.customElements.define(${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g}.is, ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g});
-  </script>
+		window.customElements.define(${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g}.is, ${2/(?:\<(\w)(\w*)\>)?\W*/\u$1\L$2\E/g});
+	</script>
 </dom-module>
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->


### PR DESCRIPTION
Snippets that are relatively synonymous with the `pe` and `pes` snippets, but with the new ES6 spec used with polymer 2.0. 

The `pe2` and `pes2` shortcuts are used to generate the boilerplate element code, the latter being near-identical but with an external stylesheet reference instead. Could also be logically changed to `p2e`, or replace `pe` and have the original polymer element snippet have a different shortcut, such as `pel` (for legacy).

For both, the tab fields follow similarly to their legacy counterparts, with `$1` at the start polymer import path, `$2` filling in the name of the element in all relevant fields, and, for the external stylesheet snippet, `$3` is used to fill the name of the stylesheet to use.

There is also a regex substitution in 3 places that turns the `$2` field from its expected slug-case to camelCase for use as the class name at declaration, and in the two arguments of the final `window.customElements.define()` call for the element.

Other than the regex-replacement, the only other relative difference from the original polymer element snippets are a default properties definition, with one property named `prop1` that has a string value set by field `$2` and a `<h2>Hello [[prop1]]</h2>` in the template (similar to the polymer-cli element boilerplate).