### PR TITLE
Add snippet for Polymer 2 elements (Class based)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,35 @@ OR, start typing the prefix for an element and hit `ctrl+space` to fuzzy search 
 </dom-module>
 ```
 
+### [pecb] polymer element with ES6 Class (Polymer 2)
+
+_Note:_ the `${1}` var is transformed to camelCase where appropriate.
+
+```html
+<dom-module id="${1}">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+  </template>
+  <script>
+    class ${1} extends Polymer.Element {
+      static get is() {
+        return '${1}';
+      }
+
+      static get properties() {
+        return {};
+      }
+    }
+
+    customElements.define(${1}.is, ${1});
+  </script>
+</dom-module>
+```
+
 ### [hi] html import *(I use this one a lot)*
 
 ```html

--- a/polymer-element-class-based.sublime-snippet
+++ b/polymer-element-class-based.sublime-snippet
@@ -1,0 +1,29 @@
+<snippet>
+  <content><![CDATA[
+<dom-module id="${1}">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+  </template>
+  <script>
+    class ${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g} extends Polymer.Element {
+      static get is() {
+        return '${1}';
+      }
+
+      static get properties() {
+        return {};
+      }
+    }
+
+    customElements.define(${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g}.is, ${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g});
+  </script>
+</dom-module>
+]]></content>
+  <tabTrigger>pecb</tabTrigger>
+  <scope>text.html</scope>
+  <description>polymer 2 element (ES6 Class)</description>
+</snippet>

--- a/polymer-element-class-based.sublime-snippet
+++ b/polymer-element-class-based.sublime-snippet
@@ -1,29 +1,29 @@
 <snippet>
-  <content><![CDATA[
+	<content><![CDATA[
 <dom-module id="${1}">
-  <template>
-    <style>
-      :host {
-        display: block;
-      }
-    </style>
-  </template>
-  <script>
-    class ${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g} extends Polymer.Element {
-      static get is() {
-        return '${1}';
-      }
+  	<template>
+		<style>
+			:host {
+				display: block;
+			}
+		</style>
+	</template>
+	<script>
+		class ${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g} extends Polymer.Element {
+			static get is() {
+				return '${1}';
+			}
 
-      static get properties() {
-        return {};
-      }
-    }
+			static get properties() {
+				return {};
+			}
+		}
 
-    customElements.define(${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g}.is, ${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g});
-  </script>
+		customElements.define(${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g}.is, ${1/^(\w)|(?:-(\w))/(?1$1:)(?2\u$2:)/g});
+	</script>
 </dom-module>
 ]]></content>
-  <tabTrigger>pecb</tabTrigger>
-  <scope>text.html</scope>
-  <description>polymer 2 element (ES6 Class)</description>
+	<tabTrigger>pecb</tabTrigger>
+	<scope>text.html</scope>
+	<description>polymer 2 element (ES6 Class)</description>
 </snippet>


### PR DESCRIPTION
The `${1}` variable is replaced by its camelCase version in the class name and `customElements`.
The tabtrigger is `pecb` (Polymer Element Class Based)

![screen recording 2018-02-01 at 12 57 a m](https://user-images.githubusercontent.com/92611/35772037-60de1c98-0937-11e8-8397-c4dcd6ab1d0a.gif)
